### PR TITLE
feat:support parameter modify url

### DIFF
--- a/bin/helper.dart
+++ b/bin/helper.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:iconfont_convert/iconfont_convert.dart';
+import 'package:iconfont_convert/src/iconfont_context.dart';
+import 'package:yaml/yaml.dart';
+
+class ConvertHelper {
+  /// Modify after execution is completed
+  static Function? modifyIconUrlToFile;
+
+  /// Check args and temporary modify url
+  static modifyIconUrl() {
+    if (context.url.isEmpty == true) {
+      return;
+    }
+    final allIcons = <IconFontYamlConfigItem>[];
+    for (var element in context.iconFonts) {
+      element["icons"].forEach((element) {
+        allIcons.add(IconFontYamlConfigItem.fromJson(element));
+      });
+    }
+    if (allIcons.isEmpty) {
+      throw ConvertException("please config iconFont in pubspec.yaml");
+    }
+    final IconFontYamlConfigItem? targetIcon;
+    if (context.name.isEmpty == true) {
+      if(allIcons.length>1){
+        throw ConvertException("please use -n set icon_name,because has multiple icon!");
+      }
+      targetIcon = allIcons.first;
+    } else {
+      targetIcon = allIcons.firstWhereOrNull(
+          (element) => element.iconName == context.name);
+    }
+    if (targetIcon == null) {
+      throw ConvertException("can not find icon");
+    }
+    final oldUrl = targetIcon.url;
+    targetIcon.oriData["url"] = context.url;
+    if (oldUrl != context.url) {
+      print(
+          "replace ${targetIcon.iconName} url from $oldUrl to ${context.url}");
+    }
+    modifyIconUrlToFile = () {
+      final configFile = File(context.config);
+      final contents = configFile.readAsStringSync();
+      var lines = contents.split('\n');
+      final index = lines.indexWhere((element) => element.contains(oldUrl!));
+      lines[index] = lines[index].replaceAll(RegExp(":.*"), ": ${context.url}");
+      configFile.writeAsStringSync(lines.join("\n"));
+    };
+  }
+
+  static parseArgResults(argResults) {
+    context = Args(argResults['name'] ?? "", argResults['url'] ?? "",
+        argResults['config'] ?? Constants.pubspecConfig);
+    final configFile = File(context.config);
+    if (!configFile.existsSync()) {
+      throw ConvertException("config file is not exist");
+    }
+    final yamlConfig =
+        jsonDecode(jsonEncode(loadYaml(configFile.readAsStringSync())));
+    context.configJson = yamlConfig;
+  }
+}

--- a/bin/iconfont_convert.dart
+++ b/bin/iconfont_convert.dart
@@ -1,6 +1,9 @@
 import 'package:args/args.dart';
 import 'package:iconfont_convert/iconfont_convert.dart';
+import 'package:iconfont_convert/src/iconfont_context.dart';
 import 'package:iconfont_convert/src/pub.dart';
+
+import 'helper.dart';
 
 void main(List<String> args) async {
   final ArgParser argParser = ArgParser()
@@ -8,6 +11,11 @@ void main(List<String> args) async {
         abbr: 'c',
         defaultsTo: Constants.pubspecConfig,
         help: "config file path")
+    ..addOption('url',
+        abbr: 'u',
+        help:
+            "config css url, auto modify config file, eg: //at.alicdn.com/t/c/font_3292250_zihkyvr4dq.css")
+    ..addOption('name', abbr: 'n', help: "if exist multiple icon,to specify icon-name.use with -url.")
     ..addFlag('help', abbr: 'h', negatable: false, help: "help");
 
   ArgResults argResults = argParser.parse(args);
@@ -15,12 +23,17 @@ void main(List<String> args) async {
     print(argParser.usage);
     return;
   }
-
   try {
-    await IconFontBuilder.buildFromYamlConfig(argResults['config']);
+    ConvertHelper.parseArgResults(argResults);
+    ConvertHelper.modifyIconUrl();
+    await IconFontBuilder.buildFromYamlConfig();
     await Pub.save();
+    ConvertHelper.modifyIconUrlToFile?.call();
   } catch (e, s) {
     print(e.toString());
+    if(e is ConvertException){
+      return;
+    }
     print(s.toString());
   }
 }

--- a/lib/src/iconfont_config.dart
+++ b/lib/src/iconfont_config.dart
@@ -70,6 +70,7 @@ class IconFontYamlConfigItem {
   String? iconClass;
   String? fontFamily;
   String? package;
+  late Map<String, dynamic> oriData;
 
   IconFontYamlConfigItem({
     this.url,
@@ -80,6 +81,7 @@ class IconFontYamlConfigItem {
   });
 
   IconFontYamlConfigItem.fromJson(Map<String, dynamic> json) {
+    oriData = json;
     url = json['url'];
     iconName = json['icon_name'];
     iconClass = json['icon_class'];

--- a/lib/src/iconfont_context.dart
+++ b/lib/src/iconfont_context.dart
@@ -1,0 +1,34 @@
+
+import 'package:path/path.dart' as path;
+import '../iconfont_convert.dart';
+
+
+class ConvertException implements Exception {
+  final dynamic message;
+
+  ConvertException([this.message]);
+
+  @override
+  String toString() {
+    return message;
+  }
+}
+
+class Args {
+  String name;
+  String url;
+  String config;
+  // configContent
+  late dynamic configJson;
+
+  List get iconFonts {
+    if (path.basename(config) == Constants.pubspecConfig) {
+      return configJson["iconfont"] ?? [];
+    }
+    return configJson;
+  }
+
+  Args(this.name, this.url, this.config);
+}
+
+late Args context;


### PR DESCRIPTION
Hi,目前修改图标需要同时要执行命令行和修改配置文件，这很割裂。所以我增加了两个参数，支持命令行修改配置文件。

```
-c, --config    config file path
                (defaults to "pubspec.yaml")
-u, --url       config css url, auto modify config file, eg: //at.alicdn.com/t/c/font_3292250_zihkyvr4dq.css
-n, --name      if exist multiple icon,to specify icon-name.use with -url.
-h, --help      help
```